### PR TITLE
Use system 'hosts' file for Xray dns resolution; Use Shecan public dns, etc.

### DIFF
--- a/v2rayn/dns_singbox_normal.json
+++ b/v2rayn/dns_singbox_normal.json
@@ -2,13 +2,13 @@
   "servers": [
     {
       "tag": "remote",
-      "address": "1.1.1.1",
+      "address": "8.8.8.8",
       "strategy": "prefer_ipv4",
       "detour": "proxy"
     },
     {
       "tag": "local",
-      "address": "8.8.8.8",
+      "address": "185.51.200.2",
       "strategy": "prefer_ipv4",
       "detour": "direct"
     },
@@ -23,6 +23,15 @@
         "geosite-category-ads-all"
       ],
       "server": "block"
+    },
+    {
+      "domain_suffix": [
+        ".ir"
+      ],
+      "geosite": [
+        "ir"
+      ],
+      "server": "local"
     }
   ],
   "final": "remote"

--- a/v2rayn/dns_v2ray_normal.json
+++ b/v2rayn/dns_v2ray_normal.json
@@ -1,12 +1,13 @@
 {
   "hosts": {
-    "geosite:category-ads-all": "127.0.0.1"
+    "dns.google": "8.8.4.4"
   },
   "servers": [
+    "8.8.8.8",
     "1.1.1.1",
-    "9.9.9.10",
+    "https://dns.google/dns-query",
     {
-      "address": "8.8.8.8",
+      "address": "178.22.122.100",
       "domains": [
         "domain:ir",
         "geosite:ir"

--- a/v2rayn/tun_singbox_dns.json
+++ b/v2rayn/tun_singbox_dns.json
@@ -2,13 +2,13 @@
   "servers": [
     {
       "tag": "remote",
-      "address": "1.1.1.1",
+      "address": "8.8.8.8",
       "strategy": "prefer_ipv4",
       "detour": "proxy"
     },
     {
       "tag": "local",
-      "address": "8.8.8.8",
+      "address": "185.51.200.2",
       "strategy": "prefer_ipv4",
       "detour": "direct"
     },
@@ -23,6 +23,15 @@
         "geosite-category-ads-all"
       ],
       "server": "block"
+    },
+    {
+      "domain_suffix": [
+        ".ir"
+      ],
+      "geosite": [
+        "ir"
+      ],
+      "server": "local"
     }
   ],
   "final": "remote"

--- a/v2rayn/v2ray.json
+++ b/v2rayn/v2ray.json
@@ -1,7 +1,7 @@
 {
-  "useSystemHosts": false,
+  "useSystemHosts": true,
   "normalDNS": "https://cdn.jsdelivr.net/gh/Chocolate4U/Iran-v2ray-rules@main/v2rayN/dns_v2ray_normal.json",
   "tunDNS": null,
-  "domainStrategy4Freedom": null,
+  "domainStrategy4Freedom": "UseIP",
   "domainDNSAddress": "8.8.8.8"
 }


### PR DESCRIPTION
…s servers for Iran domains resolution; Add Singbox dns 'direct' routing rules

سلام، 
چند تا نکته:

1. برای آدرسهای ایرانی فکر کردم بهتره از dns شِکن Shecan (که سرورش داخلی و پابلیک هست) استفاده بشه به جای گوگل. چون dns گوگل عموما خود درخواستش هم باید از پراکسی رد بشه و این باعث میشه dns resolution تمام دامین های ایرانی هم از پراکسی رد بشه که باعث تاخیر و اختلاله.
البته آپشن localhost (یعنی ارجاع درخواست از هسته به dns client مثلن خودِ ویندوز یا ....) هم موجود بود، ولی طبق تجربه من در حالت تونل مشکل ایجاد میکنه و درخواست دوباره به داخل هسته برمیگرده و .... 
با استفاده از[ dns های پابلیک شکن](https://shecan.ir/) `185.51.200.2` و` 178.22.122.100`  (فقط برای آدرسهای ایرانی) این مشکل پیش نمیاد و خطر خاص امنیتی هم به نظرم نداره.
2. پارامتر `useSystemHosts`  رو (برای هسته xray) `true `زدم چون استفاده کردن از فایل `hosts `باعث میشه خیلی از کرکهایی که خیلی از مردم استفاده میکنن از کار نیافته و مشکل خاصی هم فکر نمیکنم ایجاد کنه (من استفاده میکنم تا حالا موردی ندیدم).
3. حذف تبلیغات dns چون یکبار در قوانین روتینگ اون اومده و روش مرسومش هم هست، از قسمت dns (برای هسته xray) حذف کردم.
4. به جهت سرعت عموما بهتر  (در ایران) و اختلال کمتر دی ان اس اصلی خارج رو گوگل گذاشتم.


بهرحال اینها پیشنهاد بود و چون رپوی شماست هر جور صلاح میدونید.

ضمنا من لینکهای سی دی ان `jsdelivr ` رو با اینکه هنوز کار نمیکردن تغییر ندادم چون حدس زدم در مرحله آزمایشی هنوز آپدیت نشده (ولی قبل از PR به v2rayN باید آنلاین بشن).


با تشکر
