### PR TITLE
V2rayN routing for Iran: Add proxy bypass rule for google dns, etc.

### DIFF
--- a/v2rayN/all_except_ir.json
+++ b/v2rayN/all_except_ir.json
@@ -1,6 +1,13 @@
 [
   {
-    "port":"",
+    "outboundtag":"direct",
+    "ip":[
+      "8.8.8.8"
+    ],
+    "enabled":true,
+    "remarks":"\u062A\u0628\u062F\u06CC\u0644\u0020\u0646\u0627\u0645\u0020\u062F\u0627\u0645\u0646\u0647\u0020\u0647\u0627\u06CC\u0020\u0627\u06CC\u0631\u0627\u0646\u0020\u002d\u0020\u0645\u0633\u062A\u0642\u06CC\u0645"
+  },
+  {
     "outboundTag":"direct",
     "protocol":[
       "bittorrent"
@@ -9,7 +16,6 @@
     "remarks":"\u062a\u0648\u0631\u0646\u062a\u0020\u002d\u0020\u0645\u0633\u062a\u0642\u06cc\u0645"
   },
   {
-    "port":"",
     "outboundTag":"block",
     "domain":[
       "geosite:category-ads-all"
@@ -35,7 +41,7 @@
   },
   {
     "outboundTag":"direct",
-    "ip":[
+    "domain":[
       "geosite:ir"
     ],
     "enabled":true,

--- a/v2rayN/dns_singbox_normal.json
+++ b/v2rayN/dns_singbox_normal.json
@@ -23,6 +23,15 @@
         "geosite-category-ads-all"
       ],
       "server": "block"
+    },
+    {
+      "domain_suffix": [
+        ".ir"
+      ],
+      "geosite": [
+        "ir"
+      ],
+      "server": "local"
     }
   ],
   "final": "remote"

--- a/v2rayN/tun_singbox_dns.json
+++ b/v2rayN/tun_singbox_dns.json
@@ -23,6 +23,15 @@
         "geosite-category-ads-all"
       ],
       "server": "block"
+    },
+    {
+      "domain_suffix": [
+        ".ir"
+      ],
+      "geosite": [
+        "ir"
+      ],
+      "server": "local"
     }
   ],
   "final": "remote"

--- a/v2rayN/v2ray.json
+++ b/v2rayN/v2ray.json
@@ -1,7 +1,7 @@
 {
-  "useSystemHosts": false,
+  "useSystemHosts": true,
   "normalDNS": "https://cdn.jsdelivr.net/gh/Chocolate4U/Iran-v2ray-rules@main/v2rayN/dns_v2ray_normal.json",
   "tunDNS": null,
-  "domainStrategy4Freedom": null,
+  "domainStrategy4Freedom": "UseIP",
   "domainDNSAddress": "8.8.8.8"
 }


### PR DESCRIPTION
سلام، 
پیرو کامنتهای قبلی:

1. دی ان اس ایران رو همون گوگل استفاده میکنیم. اگه چه تاخیر یکم زیادتر شد و به حدود 100-200 ms رسید ولی عدم اتکا به سرور dns ایرانی، احتمال ارزشش رو داره (تعداد درخواستهام که خیلی محدوده). البته dns گوگل قبلا فقط در کانفیگ SingBox مستقیم بود. برای همین قانون روتینگ مستقیم رو برای اون در کانفیگ xray اضافه کردم.
3. در همون فایل `all_except_ir.json`  چند تا اشتباه یا آیتم زاید اصلاح شد. ولی ترتیب قوانین اصلی حفظ شده.
4. بقیه مواردی که موافق بودید هم اعمال شده.
