### PR TITLE
Update tun_singbox_dns.json

### DIFF
--- a/v2rayN/tun_singbox_dns.json
+++ b/v2rayN/tun_singbox_dns.json
@@ -2,19 +2,14 @@
   "servers": [
     {
       "tag": "remote",
-      "address": "1.1.1.1",
-      "strategy": "prefer_ipv4",
+      "type": "udp",
+      "server": "1.1.1.1",
       "detour": "proxy"
     },
     {
       "tag": "local",
-      "address": "8.8.8.8",
-      "strategy": "prefer_ipv4",
-      "detour": "direct"
-    },
-    {
-      "tag": "block",
-      "address": "rcode://success"
+      "type": "udp",
+      "server": "8.8.8.8"
     }
   ],
   "rules": [
@@ -22,7 +17,8 @@
       "rule_set": [
         "geosite-category-ads-all"
       ],
-      "server": "block"
+      "action": "predefined",
+      "rcode": "NXDOMAIN"
     },
     {
       "domain_suffix": [
@@ -34,5 +30,6 @@
       "server": "local"
     }
   ],
+  "strategy": "ipv4_only",
   "final": "remote"
 }


### PR DESCRIPTION
V2rayN Log Error:

WARN[0000] legacy DNS servers is deprecated in sing-box 1.12.0 and will be removed in sing-box 1.14.0, checkout documentation for migration: https://sing-box.sagernet.org/migration/#migrate-to-new-dns-server-formats

FATAL[0000] decode config at configPre.json: dns.servers[0].address: json: unknown field "address"

FATAL[0000] decode config at configPre.json: dns.rules[1].rcode: unknown rcode: SUCCESS

FATAL[0000] start service: start dns/udp[local]: detour to an empty direct outbound makes no sense


تمام ارور های بالا با این نسخه اصلاح شده رفع شدند و با آخرین ورژن sing-box سازگار شدند